### PR TITLE
add setter to override template binding regex

### DIFF
--- a/src/components/templateHelper.ts
+++ b/src/components/templateHelper.ts
@@ -62,6 +62,14 @@ export class TemplateHelper {
 
   private static _expression = /{{+\s*[$\w\.()\[\]]+\s*}}+/g;
 
+  /**
+   * Overrides the expression used in template binding.
+   * @param expression regular expression to be used in template binding
+   */
+  public static set templateBindingExpression(expression: RegExp | string) {
+    this._expression = typeof (expression) === "string" ? new RegExp(expression) : expression;
+  }
+
   private static expandExpressionsAsString(str: string, context: object, additionalContext: object) {
     return str.replace(this._expression, match => {
       const value = this.evalInContext(this.trimExpression(match), { ...context, ...additionalContext });
@@ -227,7 +235,7 @@ export class TemplateHelper {
     try {
       result = func.call(context);
       // tslint:disable-next-line: no-empty
-    } catch (e) {}
+    } catch (e) { }
     return result;
   }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #295

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->


- Feature

### Description of the changes
Added a setter method to override the default template binding expression. Angular uses a similar expression, therefore, Angular users will need to override the default to prevent Angular binding syntax errors.

### PR checklist
- [ ] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files (`npm run setLicense`)
- [x ] Contains **NO** breaking changes

### Other information
Will update documentation in separate PR
